### PR TITLE
use inline-svg instead of svg-fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ $npm install --save narwin-pack
 - [postcss-partial-import](https://github.com/jonathantneal/postcss-partial-import),
 - [postcss-nested](https://github.com/postcss/postcss-nested),
 - [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties),
-- [postcss-svg-fragments](https://github.com/jonathantneal/postcss-svg-fragments),
+- [postcss-inline-svg](https://github.com/TrySound/postcss-inline-svg),
+- [postcss-svgo](https://github.com/ben-eb/postcss-svgo),
 - [autoprefixer](https://github.com/postcss/autoprefixer),
 - [postcss-hexrgba](https://github.com/seaneking/postcss-hexrgba)
 

--- a/index.js
+++ b/index.js
@@ -18,8 +18,13 @@ var processors = [
     defaults: {}
   },
   {
-    plugin: require('postcss-svg-fragments'),
-    namespace: 'fragments',
+    plugin: require('postcss-inline-svg'),
+    namespace: 'inline-svg',
+    defaults: {}
+  },
+  {
+    plugin: require('postcss-svgo'),
+    namespace: 'svgo',
     defaults: {}
   },
   {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "postcss": "^5.2.13",
     "postcss-custom-properties": "^5.0.2",
     "postcss-hexrgba": "^0.2.1",
+    "postcss-inline-svg": "^2.3.0",
     "postcss-nested": "^1.0.0",
     "postcss-partial-import": "^3.1.1",
-    "postcss-svg-fragments": "^2.2.0"
+    "postcss-svgo": "^2.1.6"
   }
 }


### PR DESCRIPTION
This PR will swap out the postcss plugin svg-fragments for inline-svg

The reason is that svg-fragments lacks some basic configuration options
on setting its base path. When working in a project that requires
organizing your assets in such a way that they end up being nested
deeply being able to set a reasonable base path is necessary.

See: https://github.com/jonathantneal/postcss-svg-fragments/issues/10

In addition, inline-svg is more popular. (so it seems)

This PR also adds the svgo plugin which will optimize all data uris in
the css.