### PR TITLE
Fixes #11 - Remove svgo from narwin pack.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,6 @@ var processors = [
     defaults: {}
   },
   {
-    plugin: require('postcss-svgo'),
-    namespace: 'svgo',
-    defaults: {}
-  },
-  {
     plugin: require('autoprefixer'),
     defaults: { browsers: ['last 2 versions']}
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "postcss-hexrgba": "^0.2.1",
     "postcss-inline-svg": "^2.3.0",
     "postcss-nested": "^1.0.0",
-    "postcss-partial-import": "^3.1.1",
-    "postcss-svgo": "^2.1.6"
+    "postcss-partial-import": "^3.1.1"
   }
 }


### PR DESCRIPTION
SVGO has broken 2 of the 4 SVGs I've used in Telescope while attempting to over optimize them. 

The UXD team puts energy into exporting the lightest possible SVGs already, there is no need to have a plugin over optimizing and changing visual display of SVGs on page.