### PR TITLE
Add namespace to `autoprefixer` plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ var processors = [
   },
   {
     plugin: require('autoprefixer'),
+    namespace: 'autoprefixer',
     defaults: { browsers: ['last 2 versions']}
   },
   {


### PR DESCRIPTION
Without a namespace, consumer apps won't be able to provide custom plugin options.

Fixes #21